### PR TITLE
node.set is deprecated and will be removed in Chef 14.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## unreleased
+
+Features:
+
+  - Used default attribute scope for daemons (@robbat2)
+
 ## 0.3.8 (2017-05-09)
 
 Features:

--- a/recipes/bgpd.rb
+++ b/recipes/bgpd.rb
@@ -20,7 +20,7 @@
 # limitations under the License.
 #
 
-node.set['quagga']['daemons']['bgpd'] = true
+node.default['quagga']['daemons']['bgpd'] = true
 
 include_recipe 'quagga'
 

--- a/recipes/ospf6d.rb
+++ b/recipes/ospf6d.rb
@@ -20,7 +20,7 @@
 # limitations under the License.
 #
 
-node.set['quagga']['daemons']['ospf6d'] = true
+node.default['quagga']['daemons']['ospf6d'] = true
 
 include_recipe 'quagga'
 

--- a/recipes/ospfd.rb
+++ b/recipes/ospfd.rb
@@ -20,7 +20,7 @@
 # limitations under the License.
 #
 
-node.set['quagga']['daemons']['ospfd'] = true
+node.default['quagga']['daemons']['ospfd'] = true
 
 include_recipe 'quagga'
 


### PR DESCRIPTION
Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>