### PR TITLE
not_if expects a string or block.

### DIFF
--- a/recipes/bgpd.rb
+++ b/recipes/bgpd.rb
@@ -25,5 +25,5 @@ node.default['quagga']['daemons']['bgpd'] = true
 include_recipe 'quagga'
 
 quagga_bgp 'bgp' do
-  not_if node['quagga']['bgp'].empty?
+  not_if { node['quagga']['bgp'].empty? }
 end

--- a/recipes/ospf6d.rb
+++ b/recipes/ospf6d.rb
@@ -25,5 +25,5 @@ node.default['quagga']['daemons']['ospf6d'] = true
 include_recipe 'quagga'
 
 quagga_ospf6 'ospf6' do
-  not_if node['quagga']['ospf6']['areas'].empty?
+  not_if { node['quagga']['ospf6']['areas'].empty? }
 end

--- a/recipes/ospfd.rb
+++ b/recipes/ospfd.rb
@@ -25,5 +25,5 @@ node.default['quagga']['daemons']['ospfd'] = true
 include_recipe 'quagga'
 
 quagga_ospf 'ospf' do
-  not_if node['quagga']['ospf']['areas'].empty?
+  not_if { node['quagga']['ospf']['areas'].empty? }
 end

--- a/recipes/zebra.rb
+++ b/recipes/zebra.rb
@@ -6,7 +6,7 @@
 include_recipe 'quagga'
 
 quagga_zebra 'zebra' do
-  not_if node['quagga']['prefix_lists'].empty? &&
+  not_if { node['quagga']['prefix_lists'].empty? &&
          node['quagga']['interfaces'].empty? &&
-         node['quagga']['static_routes'].empty?
+         node['quagga']['static_routes'].empty? }
 end


### PR DESCRIPTION
This prevents the following error:
  quagga_zebra[zebra] (quagga::zebra line 8) had an error: ArgumentError: Invalid only_if/not_if command, expected a string: true (TrueClass)

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>